### PR TITLE
Ignore APNS service

### DIFF
--- a/src/main/java/com/wine/to/up/notification/service/mobile/apns/ApnsService.java
+++ b/src/main/java/com/wine/to/up/notification/service/mobile/apns/ApnsService.java
@@ -14,6 +14,8 @@ import java.net.URISyntaxException;
 import java.util.concurrent.ExecutionException;
 
 //@Service
+// ^ This annotation needs to be commented until we get a valid certificate from iOS team,
+// otherwise the app will fail to run
 @Slf4j
 /**
  * A service used to send push notifications to Apple devices

--- a/src/main/java/com/wine/to/up/notification/service/mobile/apns/ApnsService.java
+++ b/src/main/java/com/wine/to/up/notification/service/mobile/apns/ApnsService.java
@@ -7,13 +7,13 @@ import com.eatthepath.pushy.apns.util.SimpleApnsPushNotification;
 import com.wine.to.up.notification.service.domain.model.apns.ApnsPushNotificationRequest;
 import com.wine.to.up.notification.service.mobile.NotificationSender;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
+//import org.springframework.stereotype.Service;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.concurrent.ExecutionException;
 
-@Service
+//@Service
 @Slf4j
 /**
  * A service used to send push notifications to Apple devices

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,8 +26,4 @@ app.notifications.defaults={token: 'c-mBWsTPQKaPuD9jW29dzC:APA91bGIVjnp9mZflv6oE
 apns.file-path=${APNS_FILE_PATH:/single-topic-client.p12}
 apns.file-password=${APNS_FILE_PASSWORD:pushy-test}
 
-# Default variables are temporary - until we get the certificate from ios team
-apns.key-file=${APNS_KEY_FILE:filename}
-apns.team-id=${APNS_TEAM_ID:teamId}
-apns.key-id=${APNS_KEY_ID:keyId}
 # flyway properties - https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html#data-migration-properties


### PR DESCRIPTION
Removed `@service` annotation for `ApnsService` because we don't have the certificate yet, which causes errors when starting service